### PR TITLE
Implement 'prefetch'

### DIFF
--- a/pipes-concurrency.cabal
+++ b/pipes-concurrency.cabal
@@ -31,6 +31,7 @@ Source-Repository head
 Library
     Build-Depends:
         base         >= 4       && < 5  ,
+        async        >= 2,
         pipes        >= 3.0     && < 3.4,
         stm          >= 2.4     && < 2.5,
         transformers >= 0.2.0.0 && < 0.4


### PR DESCRIPTION
'prefetch' takes a 'Proxy' and a 'runProxy' interpreter, and runs
the session concurrently. 'prefetch' is parameterized with 'n' to
specify how many 'response's should be prefetched.

I have used the 'async' library to implement this, which is in the
Haskell platform.
