### PR TITLE
Add a simple test file to test termination/non-termination

### DIFF
--- a/pipes-concurrency.cabal
+++ b/pipes-concurrency.cabal
@@ -1,6 +1,6 @@
 Name: pipes-concurrency
 Version: 1.2.0
-Cabal-Version: >=1.8.0.2
+Cabal-Version: >=1.9.2
 Build-Type: Simple
 License: BSD3
 License-File: LICENSE
@@ -37,3 +37,14 @@ Library
         Control.Proxy.Concurrent,
         Control.Proxy.Concurrent.Tutorial
     GHC-Options: -O2
+
+Test-Suite tests
+    Type: exitcode-stdio-1.0
+    Main-Is: tests-main.hs
+    HS-Source-Dirs: tests .
+    Build-Depends:
+        base         >= 4       && < 5  ,
+        pipes        >= 3.0     && < 3.4,
+        stm          >= 2.4     && < 2.5,
+        -- and additionally:
+        async        >= 2.0     && < 2.1

--- a/tests/tests-main.hs
+++ b/tests/tests-main.hs
@@ -1,0 +1,102 @@
+module Main ( main ) where
+
+import Control.Concurrent
+import Control.Concurrent.Async
+import Control.Proxy
+import Control.Proxy.Concurrent
+import System.Exit
+import System.IO
+import System.Timeout
+
+defaultTimeout :: Int
+defaultTimeout = 100000         -- 0.1 s
+
+labelPrintD :: (Show a, Proxy p) => String -> x -> p x a x a IO r
+labelPrintD label = runIdentityK $ foreverK $ \x -> do
+  a <- request x
+  lift $ putStrLn $ label ++ ": " ++ show a
+  respond a
+
+testSenderClose :: Buffer Int -> IO ()
+testSenderClose buffer = do
+  (input, output) <- spawn buffer
+  t1 <- async $ do
+    runProxy $ fromListS [1..5] >-> sendD input
+    performGC
+  t2 <- async $ do
+    runProxy $ recvS output >-> execD (threadDelay 1000) >-> printD
+    performGC
+  wait t1
+  wait t2
+
+testSenderCloseDelayedSend :: Buffer Int -> IO ()
+testSenderCloseDelayedSend buffer = do
+  (input, output) <- spawn buffer
+  t1 <- async $ do
+    runProxy $ fromListS [1..5] >-> sendD input >-> execD (threadDelay 2000)
+    performGC
+  t2 <- async $ do
+    runProxy $ recvS output >-> execD (threadDelay 1000) >-> printD
+    performGC
+  wait t1
+  wait t2
+
+testReceiverClose :: Buffer Int -> IO ()
+testReceiverClose buffer = do
+  (input, output) <- spawn buffer
+  t1 <- async $ do
+    runProxy $ fromListS [1..] >-> sendD input >-> execD (threadDelay 1000) >-> printD
+    performGC
+  t2 <- async $ do
+    runProxy $ recvS output >-> takeB 10
+    performGC
+  wait t1
+  wait t2
+
+testReceiverCloseDelayedReceive :: Buffer Int -> IO ()
+testReceiverCloseDelayedReceive buffer = do
+  (input, output) <- spawn buffer
+  t1 <- async $ do
+    runProxy $ fromListS [1..] >-> sendD input >-> execD (threadDelay 1000) >-> labelPrintD "Send"
+    performGC
+  t2 <- async $ do
+    runProxy $ recvS output >-> takeB 10 >-> execD (threadDelay 800) >-> labelPrintD "Recv"
+    performGC
+  wait t1
+  wait t2
+
+runTest :: IO () -> String -> IO ()
+runTest test name = do
+  putStrLn $ "Starting test: " ++ name
+  hFlush stdout
+  result <- timeout defaultTimeout test
+  case result of
+    Nothing -> do putStrLn $ "Test " ++ name ++ " timed out. Aborting."
+                  exitFailure
+    Just _  -> do putStrLn $ "Test " ++ name ++ " finished."
+  hFlush stdout
+
+runTestExpectTimeout :: IO () -> String -> IO ()
+runTestExpectTimeout test name = do
+  putStrLn $ "Starting test: " ++ name
+  hFlush stdout
+  result <- timeout defaultTimeout test
+  case result of
+    Nothing -> do putStrLn $ "Test " ++ name ++ " timed out as expected."
+    Just _  -> do putStrLn $ "Test " ++ name ++ " finished, but a timeout was expected. Aborting."
+                  exitFailure
+  hFlush stdout
+
+main :: IO ()
+main = do
+  runTest (testSenderClose Unbounded) "UnboundedSenderClose"
+  runTest (testSenderClose $ Bounded 3) "BoundedFilledSenderClose"
+  runTest (testSenderClose $ Bounded 7) "BoundedNotFilledSenderClose"
+  runTest (testSenderClose Single) "SingleSenderClose"
+  runTestExpectTimeout (testSenderCloseDelayedSend $ Latest 42) "LatestSenderClose"
+  --
+  runTest (testReceiverClose Unbounded) "UnboundedReceiverClose"
+  runTest (testReceiverClose $ Bounded 3) "BoundedFilledReceiverClose"
+  runTest (testReceiverClose $ Bounded 7) "BoundedNotFilledReceiverClose"
+  runTest (testReceiverClose Single) "SingleReceiverClose"
+  runTest (testReceiverCloseDelayedReceive $ Latest 42) "LatestReceiverClose"


### PR DESCRIPTION
The purpose of these tests is to actually check with all kind of
mailboxes that the concurrent pipes terminate (or not terminate) as
expected when either the producer or the consumer stops.
This way we can detect these tricky regressions when the underlying
implementation changes.

Much more could be usefully tested in this library, but this behavior testing seems especially important.

You can try it like this:

```
cabal configure --enable-tests
cabal build
cabal test
```
