### PR TITLE
Changed `send` and `seal` to be `IO` actions

### DIFF
--- a/pipes-concurrency.cabal
+++ b/pipes-concurrency.cabal
@@ -1,5 +1,5 @@
 Name: pipes-concurrency
-Version: 2.0.1
+Version: 2.1.0
 Cabal-Version: >=1.8.0.2
 Build-Type: Simple
 License: BSD3


### PR DESCRIPTION
The `STM` requirement for `send` actually makes most use cases more difficult.
For example, to convert an action of type `a -> IO Bool` to an `Output`, you
have to use `spawn'`, which is overkill.  There seems to be no benefit to
preserving `STM` and there are many benefits to simplifying it to `IO`.

I'm leaving this pull request open for a week for others to review and comment on.  If there are no comments then I will merge it into `master` and upload to Hackage as version 2.1.0.
