### PR TITLE
feature: added a new buffer type 'LatestOnce'

### DIFF
--- a/tests/tests-main.hs
+++ b/tests/tests-main.hs
@@ -114,9 +114,11 @@ main = do
     runTest (testSenderClose $ Bounded 7) "BoundedNotFilledSenderClose"
     runTest (testSenderClose Single) "SingleSenderClose"
     runTestExpectTimeout (testSenderCloseDelayedSend $ Latest 42) "LatestSenderClose"
+    runTest (testSenderCloseDelayedSend New) "NewSenderClose"
     --
     runTest (testReceiverClose Unbounded) "UnboundedReceiverClose"
     runTest (testReceiverClose $ Bounded 3) "BoundedFilledReceiverClose"
     runTest (testReceiverClose $ Bounded 7) "BoundedNotFilledReceiverClose"
     runTest (testReceiverClose Single) "SingleReceiverClose"
     runTest (testReceiverCloseDelayedReceive $ Latest 42) "LatestReceiverClose"
+    runTest (testReceiverClose New) "NewReceiverClose"


### PR DESCRIPTION
LatestOnce: Like Latest but the 'Latest' message can be read out of the
mailbox just once. Any other read attempt will block until new messages 
arrive - writers should not block.

Maybe a stupid buffer type but most probably a stupid name for the buffer.
