### PR TITLE
Explicitly discard values using `void`

### DIFF
--- a/src/Pipes/Concurrent.hs
+++ b/src/Pipes/Concurrent.hs
@@ -32,7 +32,7 @@ import Control.Applicative (
 import Control.Concurrent (forkIO)
 import Control.Concurrent.STM (atomically, STM, mkWeakTVar, newTVarIO, readTVar)
 import qualified Control.Concurrent.STM as S
-import Control.Monad (when)
+import Control.Monad (when,void)
 import Data.Monoid (Monoid(mempty, mappend))
 import Pipes (MonadIO(liftIO), yield, await, Producer', Consumer')
 import System.Mem (performGC)
@@ -179,9 +179,9 @@ spawn' buffer = do
        collected.
     -}
     rSend <- newTVarIO ()
-    mkWeakTVar rSend (S.atomically seal)
+    void $ mkWeakTVar rSend (S.atomically seal)
     rRecv <- newTVarIO ()
-    mkWeakTVar rRecv (S.atomically seal)
+    void $ mkWeakTVar rRecv (S.atomically seal)
 
     let sendOrEnd a = do
             b <- S.readTVar sealed


### PR DESCRIPTION
Hi,

just a minor thing, when looking through the code, ghc complained with:

```
Warning: A do-notation statement discarded a result of type
  ‘GHC.Weak.Weak (S.TVar ())’
```

So I just quickly added two `void`.

[![24pullrequests](http://24pullrequests.com/assets/logo-625222452ffc0d57272decb6f851a7fe.png)](http://24pullrequests.com)

Best,
Markus
