### PR TITLE
Added Contravariant instance for Output

### DIFF
--- a/pipes-concurrency.cabal
+++ b/pipes-concurrency.cabal
@@ -31,9 +31,10 @@ Source-Repository head
 Library
     Hs-Source-Dirs: src
     Build-Depends:
-        base         >= 4     && < 5  ,
-        pipes        >= 4.0   && < 4.2,
-        stm          >= 2.4.3 && < 2.5
+        base          >= 4     && < 5  ,
+        contravariant >= 1.3.3 && < 1.4,
+        pipes         >= 4.0   && < 4.2,
+        stm           >= 2.4.3 && < 2.5
     Exposed-Modules:
         Pipes.Concurrent,
         Pipes.Concurrent.Tutorial

--- a/src/Pipes/Concurrent.hs
+++ b/src/Pipes/Concurrent.hs
@@ -35,6 +35,7 @@ import Control.Concurrent.STM (atomically, STM, mkWeakTVar, newTVarIO, readTVar)
 import qualified Control.Concurrent.STM as S
 import Control.Exception (bracket)
 import Control.Monad (when,void, MonadPlus(..))
+import Data.Functor.Contravariant (Contravariant(contramap))
 import Data.Monoid (Monoid(mempty, mappend))
 import Pipes (MonadIO(liftIO), yield, await, Producer', Consumer')
 import System.Mem (performGC)
@@ -87,6 +88,11 @@ newtype Output a = Output {
 instance Monoid (Output a) where
     mempty  = Output (\_ -> return False)
     mappend i1 i2 = Output (\a -> (||) <$> send i1 a <*> send i2 a)
+
+-- | This instance is useful for creating new tagged address, similar to elm's
+-- Signal.forwardTo. In fact elm's forwardTo is just 'flip contramap'
+instance Contravariant Output where
+    contramap f (Output a) = Output (a . f)
 
 {-| Convert an 'Output' to a 'Pipes.Consumer'
 


### PR DESCRIPTION
Hi Gabriel, great work on the Pipes.Concurrency.

I find it really interesting that Pipes's `(Output, Input)` is equivalent to elms' Mailbox of `(Address, Signal)`.

Elm has an api called [forwardTo](http://package.elm-lang.org/packages/elm-lang/core/2.1.0/Signal#forwardTo) which is actually `flip contramap`.

So I added a contravariant instance for `Output` so it can be used in a similar way.

Cheers,

Louis