### PR TITLE
Add Divisible and Decidable instances for Output.

### DIFF
--- a/pipes-concurrency.cabal
+++ b/pipes-concurrency.cabal
@@ -34,7 +34,8 @@ Library
         base          >= 4     && < 5  ,
         contravariant >= 1.3.3 && < 1.4,
         pipes         >= 4.0   && < 4.2,
-        stm           >= 2.4.3 && < 2.5
+        stm           >= 2.4.3 && < 2.5,
+        void          >= 0.6   && < 1
     Exposed-Modules:
         Pipes.Concurrent,
         Pipes.Concurrent.Tutorial


### PR DESCRIPTION
Since Output now has a Contravariant instance, it might as well also have instances for the Divisible and Decidable classes, which are the contravariant equivalents of Input's Applicative and Alternative instances.

The instances should obey the Divisible/Decidable laws, since they are essentially just specializations of the Op r instances from the contravariant package.